### PR TITLE
Remove premium service white hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -768,9 +768,9 @@ body {
 
 .service-box:hover {
   transform: translateY(-15px) scale(1.02);
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 215, 0, 0.08);
   border-color: var(--primary-gold);
-  box-shadow: 0 25px 60px rgba(255, 215, 0, 0.2);
+  box-shadow: 0 25px 60px rgba(255, 215, 0, 0.3);
 }
 
 .service-icon {


### PR DESCRIPTION
Remove white hover effect from premium service boxes and enhance golden glow for a more cohesive and polished look.

---
<a href="https://cursor.com/background-agent?bcId=bc-d37d16cb-cb12-48c1-a989-76963c0988a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d37d16cb-cb12-48c1-a989-76963c0988a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

